### PR TITLE
Fix missing video recordings for iOS and Android devices

### DIFF
--- a/src/plugin/driver-command-executor.ts
+++ b/src/plugin/driver-command-executor.ts
@@ -5,6 +5,10 @@ async function startScreenRecording(driver: any, sessionId: string) {
     options: {
       videoType: "libx264",
       videoFps: 10,
+      /* Force iOS video scale to fix '[ffmpeg] [libx264 @ 0x7fda5f005280] width not divisible by 2 (1125x2436)' */
+      videoScale: "1280:720",
+      /* Force Android size because some devices cannot record at their native resolution, resulting in error 'Unable to get output buffers (err=-38)' */
+      videoSize: "1280:720",
       /* In android, adb can record only 3 mins of video. below timeLimit is used to take longer video */
       timeLimit: 1800, //in seconds (30 min)
     },


### PR DESCRIPTION
Add `videoScale` for iOS and `videoSize` for Android when starting video recordings to set the video resolution.  This solves issues where no video gets recorded for tests.  For iOS it fixes this issue seen in Appium logs:

```shell
2023-03-01 14:02:28:732 - [ffmpeg] [libx264 @ 0x7fda5f005280] width not divisible by 2 (1125x2436)
```

For Android is solves an issue where the device cannot record video at full resolution.

```shell
Display is 1440x3040 @60.00fps (orientation=ROTATION_0), layerStack=0
Configuring recorder for 1440x3040 video/avc at 20.00Mbps
Content area is 1440x3040 at offset x=0 y=0
Stopping encoder and muxer
Unable to get output buffers (err=-38)
Encoder failed (err=-38)
```

Fixes #81 