### PR TITLE
Enable users to set video recording resolution and fix Android recording

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-dashboard",
-  "version": "v2.0.1",
+  "version": "v2.0.2",
   "description": "Appium plugin to view session execution details via detailed dashboard",
   "main": "lib/index.js",
   "scripts": {

--- a/src/plugin/driver-command-executor.ts
+++ b/src/plugin/driver-command-executor.ts
@@ -1,14 +1,20 @@
 import { makeGETCall, makePostCall, makeDELETECall } from "./utils/plugin-utils";
 
-async function startScreenRecording(driver: any, sessionId: string) {
+async function startScreenRecording(driver: any, sessionId: string, videoResolution: string) {
+  let resolution = "1280:720";
+  let size = "1280x720";
+  if (videoResolution) {
+    resolution = videoResolution.replace("x", ":");
+    size = videoResolution.replace(":", "x");
+  }
   return await makePostCall(driver, sessionId, "/appium/start_recording_screen", {
     options: {
       videoType: "libx264",
       videoFps: 10,
       /* Force iOS video scale to fix '[ffmpeg] [libx264 @ 0x7fda5f005280] width not divisible by 2 (1125x2436)' */
-      videoScale: "1280:720",
+      videoScale: resolution,
       /* Force Android size because some devices cannot record at their native resolution, resulting in error 'Unable to get output buffers (err=-38)' */
-      videoSize: "1280:720",
+      videoSize: size,
       /* In android, adb can record only 3 mins of video. below timeLimit is used to take longer video */
       timeLimit: 1800, //in seconds (30 min)
     },

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -13,7 +13,7 @@ import getPort from "get-port";
 
 const sessionMap: Map<string, SessionManager> = new Map();
 const IGNORED_COMMANDS = ["getScreenshot", "stopRecordingScreen", "startRecordingScreen"];
-const CUSTOM_CAPABILITIES = ["newCommandTimeout", "dashboard:project", "dashboard:build", "dashboard:name"];
+const CUSTOM_CAPABILITIES = ["newCommandTimeout", "dashboard:project", "dashboard:build", "dashboard:name", "dashboard:videoResolution"];
 
 class AppiumDashboardPlugin extends BasePlugin {
   constructor(pluginName: string) {

--- a/src/plugin/session-manager.ts
+++ b/src/plugin/session-manager.ts
@@ -379,7 +379,9 @@ class SessionManager {
   }
 
   private async startScreenRecording(driver: any) {
-    await startScreenRecording(driver, this.sessionInfo.session_id);
+    let { desired } = this.sessionInfo.capabilities;
+    let videoResolution = desired["dashboard:videoResolution"];
+    await startScreenRecording(driver, this.sessionInfo.session_id, videoResolution);
   }
 
   private async initializeScreenShotFolder() {


### PR DESCRIPTION
Fixes an issue where iOS option `videoScale` needs value in `width:height` and Android's `videoSize` needs values in `widthxheight`.  Using version 2.0.1 on Android was causing error:

```shell
2023-03-03 09:47:49:446 - [AndroidUiautomator2Driver@ae57 (fe625e0c)] Screen recording has not been previously started by Appium. There is nothing to stop
2023-03-03 09:47:49:447 - [debug] [ADB] Getting IDs of all 'screenrecord' processes
2023-03-03 09:47:49:447 - [debug] [ADB] Running 'C:\ProgramData\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell pgrep -f \(\[\[:blank:\]\]\|\^\)screenrecord\(\[\[:blank:\]\]\|\$\)'
2023-03-03 09:47:49:653 - [debug] [ADB] Building screenrecord process with the command line: adb -P 5037 -s emulator-5554 shell screenrecord --size 1280\:720 --time-limit 180 /sdcard/889a9592.mp4
2023-03-03 09:47:49:735 - [debug] [ADB] Running 'C:\ProgramData\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell "[ -e '/sdcard/889a9592.mp4' ] && echo __PASS__"'
2023-03-03 09:47:50:248 - [debug] [ADB] Running 'C:\ProgramData\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell "[ -e '/sdcard/889a9592.mp4' ] && echo __PASS__"'
2023-03-03 09:47:50:706 - [debug] [ADB] Running 'C:\ProgramData\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell "[ -e '/sdcard/889a9592.mp4' ] && echo __PASS__"'
2023-03-03 09:47:51:178 - [debug] [ADB] Running 'C:\ProgramData\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell "[ -e '/sdcard/889a9592.mp4' ] && echo __PASS__"'
2023-03-03 09:47:51:678 - [debug] [ADB] Running 'C:\ProgramData\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell "[ -e '/sdcard/889a9592.mp4' ] && echo __PASS__"'
2023-03-03 09:47:52:138 - [debug] [ADB] Running 'C:\ProgramData\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell "[ -e '/sdcard/889a9592.mp4' ] && echo __PASS__"'
2023-03-03 09:47:52:593 - [debug] [ADB] Running 'C:\ProgramData\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell "[ -e '/sdcard/889a9592.mp4' ] && echo __PASS__"'
2023-03-03 09:47:53:094 - [debug] [ADB] Running 'C:\ProgramData\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell "[ -e '/sdcard/889a9592.mp4' ] && echo __PASS__"'
2023-03-03 09:47:53:568 - [debug] [ADB] Running 'C:\ProgramData\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell "[ -e '/sdcard/889a9592.mp4' ] && echo __PASS__"'
2023-03-03 09:47:54:040 - [debug] [ADB] Running 'C:\ProgramData\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell "[ -e '/sdcard/889a9592.mp4' ] && echo __PASS__"'
2023-03-03 09:47:54:510 - [debug] [ADB] Running 'C:\ProgramData\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell "[ -e '/sdcard/889a9592.mp4' ] && echo __PASS__"'
2023-03-03 09:47:54:741 - [debug] [ADB] Running 'C:\ProgramData\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell "[ -e '/sdcard/889a9592.mp4' ] && echo __PASS__"'
2023-03-03 09:47:54:911 - [debug] [AndroidUiautomator2Driver@ae57 (fe625e0c)] Encountered internal error running command: Error: The expected screen record file '/sdcard/889a9592.mp4' does not exist after 5000ms. Is screenrecord utility available and operational on the device under test?
2023-03-03 09:47:54:911 - [debug] [AndroidUiautomator2Driver@ae57 (fe625e0c)]     at scheduleScreenRecord (C:\Users\zgrauer1\AppData\Roaming\npm\node_modules\appium\node_modules\appium-uiautomator2-driver\node_modules\appium-android-driver\lib\commands\recordscreen.js:111:11)
2023-03-03 09:47:54:911 - [debug] [AndroidUiautomator2Driver@ae57 (fe625e0c)]     at AndroidUiautomator2Driver.startRecordingScreen (C:\Users\zgrauer1\AppData\Roaming\npm\node_modules\appium\node_modules\appium-uiautomator2-driver\node_modules\appium-android-driver\lib\commands\recordscreen.js:249:3)
```

Enables users to set the video recording size using new capability `dashboard:videoResolution`.  The resolution/size can be in formats `widthxheight` or `width:height`.

```json
{
  "appium:deviceName": "emulator-5554",
  "appium:udid": "emulator-5554",
  "appium:automationName": "UiAutomator2",
  "platformName": "Android",
  "appium:appPackage": "com.android.settings",
  "appium:appActivity": "com.android.settings.Settings",
  "dashboard:videoResolution": "1920x1080"
}
```


Appium log for test using Android emulator and no custom capability (default size)
https://gist.github.com/ZGrauer/1b3d239831093bc6778a8fc88c4ded6d

Example 1280x720
https://user-images.githubusercontent.com/20744813/222774961-d70c93c8-80f0-4067-93e6-e300de82e27c.mp4



Appium log for test using Android emulator and `dashboard:videoResolution` (custom size)
https://gist.github.com/ZGrauer/6cd9f6c7628d6deec0fe1e0141362cc1

Example 1920x1080
https://user-images.githubusercontent.com/20744813/222775044-af4b3458-8ef1-4f4f-b4d3-236cc77c571e.mp4


